### PR TITLE
The output for spin dependent and independent PDOS were inconsistent.…

### DIFF
--- a/optados/src/pdos.F90
+++ b/optados/src/pdos.F90
@@ -224,7 +224,7 @@ contains
       end do
     else
       do iproj = start_proj, stop_proj
-        write (pdos_file, '(1a,a1,a12,i4,a10,50x,a1)') '#', '|', ' Projector: ', iproj, ' contains:', '|'
+        write (pdos_file, '(1a,a1,a12,i4,a10,50x,a1)') '#', '|', ' Column: ', iproj, ' contains:', '|'
         write (pdos_file, '(1a,a1,a16,10x,a14,36x,a1)') '#', '|', ' Atom ', ' AngM Channel ', '|'
         do ispecies = 1, num_species
           do ispecies_num = 1, atoms_species_num(ispecies)
@@ -264,7 +264,7 @@ contains
     write (stdout, '(1x,a)') '|                    Partial Density of States -- Projectors                 |'
     write (stdout, '(1x,a)') '+----------------------------------------------------------------------------+'
     do iproj = 1, num_proj
-      write (stdout, '(1x,a1,a12,i4,a10,50x,a1)') '|', ' Projector: ', iproj, ' contains:', '|'
+      write (stdout, '(1x,a1,a12,i4,a10,50x,a1)') '|', ' Column: ', iproj, ' contains:', '|'
       write (stdout, '(1x,a1,a16,10x,a14,36x,a1)') '|', ' Atom ', ' AngM Channel ', '|'
 
       do ispecies = 1, num_species


### PR DESCRIPTION
The output for spin dependent and independent PDOS were inconsistent. In one case saying "Projector" and in the other "Column".  This made it non-trivial for subsequent parsers. The code now consistently says "Column."'

It is a two-line change.