### PR TITLE
fix Makefile for custom PREFIX support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+optados/od2od
+optados/optados.x
+optados/documents/*.aux
+optados/documents/*.bbl
+optados/documents/*.blg
+optados/documents/*.dvi
+optados/documents/*.log
+optados/documents/*.out
+optados/documents/*.pdf
+optados/documents/*.ps
+optados/documents/*.toc
+optados/src/build.f90

--- a/optados/documents/Makefile
+++ b/optados/documents/Makefile
@@ -9,7 +9,7 @@ all:
 	ps2pdf $(MANUAL_NAME).ps
 
 clean:
-	rm -f *.toc *.aux *.dvi *.log
+	rm -f *.toc *.aux *.dvi *.log *.bbl *.blg *.out *.ps
 
-veryclean: 
+veryclean:
 	rm -f *.pdf

--- a/optados/python/Makefile
+++ b/optados/python/Makefile
@@ -5,7 +5,7 @@ F90_FILES=../src/algorithms.f90 ../src/cell.f90 ../src/comms.F90 ../src/constant
 KIND_MAP= kind_map
 
 python:
-	f90wrap -vvvvv -m $(MODULE_NAME) $(F90_FILES)  -k $(KIND_MAP) 
+	f90wrap -vvvvv -m $(MODULE_NAME) $(F90_FILES)  -k $(KIND_MAP)
 	f2py -c -m _OptaPyDOS -I"../src" ../src/*.o f90wrap*.f90
 
 # Utility targets
@@ -15,4 +15,4 @@ clean:
 	rm -f f90wrap*
 
 veryclean: clean
-	rm -f OptaPyDOS.py  _OptaPyDOS.so
+	rm -f  _OptaPyDOS.so

--- a/optados/src/Makefile
+++ b/optados/src/Makefile
@@ -91,7 +91,7 @@ projection_utils.o : projection_utils.f90 cell.o comms.o constants.o cell.o elec
 xmgrace_utils.o : xmgrace_utils.f90 io.o constants.o ../make.system
 	$(F90) -c $(FFLAGS) $<
 
-build.f90 : 
+build.f90 :
 	./make_build_info.sh
 
 build.o : build.f90 ../make.system
@@ -104,11 +104,20 @@ build.o : build.f90 ../make.system
 
 
 clean:
-	rm -f *.o *.mod *.MOD build_info.f90
+	rm -f *.o *.mod *.MOD build_info.f90 build.f90
 
 
 veryclean: clean
-	rm -f optados$(EXTENSION) optados$(EXTENSION).debug optados$(EXTENSION).mpi ../od2od ../optados.x
+	rm -f optados$(EXTENSION) optados$(EXTENSION).debug optados$(EXTENSION).mpi ../od2od ../optados$(EXTENSION)
 
 install:
-	cp optados$(EXTENSION) $(INSTALL_DIR)
+	@if [ ! "$(abspath ../optados$(EXTENSION))" = "$(abspath $(PREFIX)/optados$(EXTENSION))" ]; then \
+	  cp ../optados$(EXTENSION) $(PREFIX)/optados$(EXTENSION); \
+	else \
+	  echo "Skipping copy optados$(EXTENSION): source and destination are the same"; \
+	fi
+	@if [ ! "$(abspath ../od2od)" = "$(abspath $(PREFIX)/od2od)" ]; then \
+	  cp ../od2od $(PREFIX)/od2od; \
+	else \
+	  echo "Skipping copy od2od: source and destination are the same"; \
+	fi


### PR DESCRIPTION
 ###  Pull Request Summary

 This PR fixes the `Makefile` installation logic to correctly support custom `PREFIX` values.  
 It avoids copying files to the same path (which previously caused errors when the source and destination were identical) and ensures that binaries are installed to the specified directory unambiguously.

 **Other changes include:**

 - Fixed the `veryclean` target in the `python/Makefile` to prevent accidental deletion of `OptaPyDOS.py`, which is likely required.
 - Added a `.gitignore` file to exclude intermediate files generated by `make all`, including files related to `TEX` in `documents` and the `build.f90` file in `src`.

These changes improve installation flexibility and development cleanliness.
